### PR TITLE
Add CXXFLAGS to allow compiling with 'constexpr'

### DIFF
--- a/hammer.sh
+++ b/hammer.sh
@@ -17,6 +17,8 @@ export CPATH="$PREFIX/include:$CPATH"
 export LDFLAGS="$LDFLAGS -L$PREFIX/lib"
 export LIBRARY_PATH="$PREFIX/lib:$LIBRARY_PATH"
 export LD_LIBRARY_PATH="$PREFIX/lib:$LD_LIBRARY_PATH"
+#allows compiling with 'constexpr'
+export CXXFLAGS="-std=gnu++11"
 
 # setup directories
 mkdir -p $PREFIX


### PR DESCRIPTION
Otherwise failed with following error on Xubuntu 12.10 x64:
../include/Mercator-0.3/Mercator/BasePoint.h:30:12: error: ‘constexpr’ does not name a type
note: C++11 ‘constexpr’ only available with -std=c++11 or -std=gnu++11
