### PR TITLE
Extensively rewrite and clean up hammer

### DIFF
--- a/README
+++ b/README
@@ -5,3 +5,6 @@ Execute hammer.sh for help.
 
 All build artifacts are placed in the "work" directory.
 
+Note: If you are building an AppImage, these scripts assumes that the 
+AppImageKit source directory is installed in the same parent directory 
+that the hammer directory is installed in.

--- a/hammer.sh
+++ b/hammer.sh
@@ -2,6 +2,24 @@
 
 set -e
 
+# Define component versions
+CEGUI_VER=cegui-0.8.3
+CEGUI_DOWNLOAD=cegui-0.8.3.tar.gz
+OGRE_VER=ogre_1_9_0
+OGRE_DOWNLOAD=v1-9-0.tar.bz2
+CG_VER=3.1
+CG_FULLVER=${CG_VER}.0013
+CG_DOWNLOAD=Cg-3.1_April2012
+FREEALUT_VER=1.1.0
+TOLUA_VER="tolua++-1.0.93"
+VARCONF_VER=1.0.1
+ATLASCPP_VER=0.6.3
+SKSTREAM_VER=0.3.9
+WFMATH_VER=1.0.2
+ERIS_VER=1.3.23
+WFUT_VER=libwfut-0.2.3
+MERCATOR_VER=0.3.3
+
 export HAMMERDIR=$PWD
 export WORKDIR=$HAMMERDIR/work
 export PREFIX=$WORKDIR/local
@@ -35,14 +53,6 @@ AUTOLOG=autogen.log     # Autogen output
 CONFIGLOG=config.log    # Configure output
 MAKELOG=build.log      # Make output
 INSTALLLOG=install.log # Install output
-
-# Dependencies
-CEGUI=cegui-0.8.3
-CEGUI_DOWNLOAD=cegui-0.8.3.tar.gz
-OGRE=ogre_1_9_0
-OGRE_DOWNLOAD=v1-9-0.tar.bz2
-CG=Cg_3.1.0013
-CG_DOWNLOAD=Cg-3.1_April2012
 
 CONFIGURE_EXTRA_FLAGS=""
 
@@ -195,49 +205,23 @@ function show_help()
     echo "Targets:"
     echo "  cegui, ogre, libs/<name>, clients/<name>, servers/<name>"
   elif [ $1 = "release_ember" ] ; then
-    echo "Change the previously checked-out ember to a specific release."
+    echo "Build a specific release of Ember, including latest stable libraries."
+    echo "Do not run this command as root, AppImage building will fail."
     echo ""
-    echo "Usage: hammer.sh release_ember <version number>"
-    echo "e.g. hammer.sh release_ember 0.7.1"
+    echo "Usage: hammer.sh release_ember <version number> [<target>]"
+    echo "Available targets [optional]:"
+    echo "  dir        - build into a standard directory structure"
+    echo "  image      - build an AppImage or AppBundle (Default)"
+    echo ""
+    echo "e.g. hammer.sh release_ember 0.7.1 dir"
   else
     echo "No help page found!"
   fi
 }
 
-# Show main help page if no arguments given
-if [ $# -eq 0 ] ; then
-  show_help "main"
-
-# If help command given, show help page
-elif [ "$1" = "help" ] ; then
-  if [ $# -eq 2 ] ; then
-    show_help $2
-  else
-    show_help "main"
-  fi
-
-  mkdir -p $PREFIX $SOURCE $DEPS_SOURCE
-
-# Dependencies install
-elif [ "$1" = "install-deps" ] ; then
-  if [ x$MSYSTEM = x"MINGW32" ] ; then
-    SCRIPTDIR=`dirname "$0"`
-    $SCRIPTDIR/mingw_install_deps.sh
-    exit 0
-  fi
-  if [ $# -ne 2 ] ; then
-    echo "Missing required parameter!"
-    show_help "install-deps"
-    exit 1
-  fi
-
-  echo "Installing deps..."
-
-  # Create deps log directory
-  mkdir -p $LOGDIR/deps
-
+function install_deps_Cg()
+{
   # Cg Toolkit
-  if [ "$2" = "all" ] || [ "$2" = "cg" ] ; then
     echo "  Installing Cg Toolkit..."
     if [[ $OSTYPE == *darwin* ]] ; then
       CG_DOWNLOAD+=".dmg"
@@ -253,47 +237,54 @@ elif [ "$1" = "install-deps" ] ; then
     fi
     mkdir -p $LOGDIR/deps/cg
     cd $DEPS_SOURCE
-    if [ ! -d $CG ]; then
+    if [ ! -d Cg_$CG_FULLVER ]; then
       echo "  Downloading..."
-      curl -C - -OL http://developer.download.nvidia.com/cg/Cg_3.1/$CG_DOWNLOAD
+      curl -C - -OL http://developer.download.nvidia.com/cg/Cg_$CG_VER/$CG_DOWNLOAD
       if [[ $OSTYPE == *darwin* ]] ; then
         hdiutil mount $CG_DOWNLOAD
-        cp "/Volumes/Cg-3.1.0013/Cg-3.1.0013.app/Contents/Resources/Installer Items/NVIDIA_Cg.tgz" .
-        hdiutil unmount "/Volumes/Cg-3.1.0013/"
+        cp "/Volumes/Cg-${CG_FULLVER}/Cg-${CG_FULLVER}.app/Contents/Resources/Installer Items/NVIDIA_Cg.tgz" .
+        hdiutil unmount "/Volumes/Cg-$CG_FULLVER/"
         CG_DOWNLOAD="NVIDIA_Cg.tgz"
       fi
-      mkdir -p $CG
-      cd $CG
+      mkdir -p Cg_$CG_FULLVER
+      cd Cg_$CG_FULLVER
       tar -xf ../$CG_DOWNLOAD
     fi
     mkdir -p $PREFIX/lib
-    cp $DEPS_SOURCE/$CG/$CG_LIB_LOCATION $PREFIX/lib
-  fi
+    cp $DEPS_SOURCE/Cg_${CG_FULLVER}/$CG_LIB_LOCATION $PREFIX/lib
+    echo "  Done."
+}
 
+function install_deps_Ogre()
+{
   # Ogre3D
-  if [ "$2" = "all" ] || [ "$2" = "ogre" ] ; then
     echo "  Installing Ogre..."
     mkdir -p $LOGDIR/deps/ogre
     cd $DEPS_SOURCE
-    if [ ! -d $OGRE ]; then
+    if [ ! -d $OGRE_VER ]; then
       echo "  Downloading..."
       curl -C - -OL https://bitbucket.org/sinbad/ogre/get/$OGRE_DOWNLOAD
-      mkdir -p $OGRE
-      cd $OGRE
+      mkdir -p $OGRE_VER
+      cd $OGRE_VER
       tar -xjf ../$OGRE_DOWNLOAD
+      OGRE_SOURCE=$DEPS_SOURCE/$OGRE_VER/`ls $DEPS_SOURCE/$OGRE_VER`
       if [[ $OSTYPE == *darwin* ]] ; then
-        cd $DEPS_SOURCE/$OGRE/`ls $DEPS_SOURCE/$OGRE`
+        cd $OGRE_SOURCE
         echo "  Patching..."
         ls .
         patch -p1 < $SUPPORTDIR/ogre_cocoa_currentGLContext_support.patch
       fi
+    else
+      OGRE_SOURCE=$DEPS_SOURCE/$OGRE_VER/`ls $DEPS_SOURCE/$OGRE_VER`
     fi
-    cd $DEPS_SOURCE/$OGRE/`ls $DEPS_SOURCE/$OGRE`
+    cd $OGRE_SOURCE
     mkdir -p $BUILDDIR
     cd $BUILDDIR
     echo "  Configuring..."
     OGRE_EXTRA_FLAGS=""
-    cmake .. -DCMAKE_INSTALL_PREFIX="$PREFIX" -DOIS_INCLUDE_DIR="" -DOGRE_BUILD_SAMPLES=false $OGRE_EXTRA_FLAGS $CMAKE_EXTRA_FLAGS > $LOGDIR/deps/ogre/$CONFIGLOG
+    # Note: The -DOIS_INCLUDE_DIR flag is only set because of sample-related build failures
+    #       which appear to be caused by Ogre 1.9.0. When fixed, this flag should be removed.
+    cmake .. -DCMAKE_INSTALL_PREFIX="$PREFIX" -DOIS_INCLUDE_DIR="/usr/lib" -DOGRE_BUILD_SAMPLES="OFF" $OGRE_EXTRA_FLAGS $CMAKE_EXTRA_FLAGS > $LOGDIR/deps/ogre/$CONFIGLOG
     if [[ $OSTYPE == *darwin* ]] ; then
       echo "  Building..."
         xcodebuild -configuration RelWithDebInfo > $LOGDIR/deps/ogre/$MAKELOG
@@ -310,18 +301,19 @@ elif [ "$1" = "install-deps" ] ; then
         make install > $LOGDIR/deps/ogre/$INSTALLLOG
         echo "  Done."
     fi
-  fi
+}
 
+function install_deps_freealut()
+{
   # freealut
-  if [ "$2" = "all" ] && [[ $OSTYPE == *darwin* ]] || [ "$2" = "freealut" ] ; then
     echo "  Installing freealut..."
     mkdir -p $LOGDIR/deps/freealut
     cd $DEPS_SOURCE
 
     echo "  Downloading..."
-    curl -C - -OL http://connect.creativelabs.com/openal/Downloads/ALUT/freealut-1.1.0-src.zip
-    unzip -o freealut-1.1.0-src.zip
-    cd freealut-1.1.0-src
+    curl -C - -OL http://connect.creativelabs.com/openal/Downloads/ALUT/freealut-${FREEALUT_VER}-src.zip
+    unzip -o freealut-${FREEALUT_VER}-src.zip
+    cd freealut-${FREEALUT_VER}-src
     if [[ $OSTYPE == *darwin* ]] ; then
       cp $SUPPORTDIR/openal.pc $PREFIX/lib/pkgconfig/openal.pc
     fi
@@ -339,10 +331,11 @@ elif [ "$1" = "install-deps" ] ; then
     make $MAKEOPTS > $LOGDIR/deps/freealut/$MAKELOG
     echo "  Installing..."
     make install > $LOGDIR/deps/freealut/$INSTALLLOG
-  fi
+}
 
+function install_deps_tolua++()
+{
   # tolua++
-  if [ "$2" = "all" ] && [[ $OSTYPE == *darwin* ]] || [ "$2" = "tolua++" ] ; then
     #the "all" keyword will only work on mac, but "tolua++" will work on linux and mac, if you set LUA_CFLAGS and LUA_LDFLAGS.
     NORMAL_LUA_VERSION="`pkg-config --modversion lua`"
     if [[ ! $NORMAL_LUA_VERSION == 5.1* ]]; then
@@ -355,11 +348,10 @@ elif [ "$1" = "install-deps" ] ; then
     if [ "x$LUA_LDFLAGS" == "x" ] ; then
       LUA_LDFLAGS="-llua"
     fi
-    TOLUA_VER="tolua++-1.0.93"
     cd $DEPS_SOURCE
     if [ ! -d $TOLUA_VER ] ; then
-        curl -OL http://www.codenix.com/~tolua/$TOLUA_VER.tar.bz2
-        tar -xjf $TOLUA_VER.tar.bz2
+        curl -OL http://www.codenix.com/~tolua/${TOLUA_VER}.tar.bz2
+        tar -xjf ${TOLUA_VER}.tar.bz2
     fi
     cd $TOLUA_VER
     mkdir -p $PREFIX/include
@@ -379,25 +371,26 @@ elif [ "$1" = "install-deps" ] ; then
     mkdir -p $PREFIX/bin
     cp tolua++ $PREFIX/bin/tolua++
     cd ../../..
-  fi
+}
 
+function install_deps_CEGUI()
+{
   # CEGUI
-  if [ "$2" = "all" ] || [ "$2" = "cegui" ] ; then
     echo "  Installing CEGUI..."
     mkdir -p $LOGDIR/deps/CEGUI    # create CEGUI log directory
     cd $DEPS_SOURCE
-    if [ ! -d $CEGUI ] ; then
+    if [ ! -d $CEGUI_VER ] ; then
       echo "  Downloading..."
       curl -C - -OL http://downloads.sourceforge.net/sourceforge/crayzedsgui/$CEGUI_DOWNLOAD
-      tar zxvf $CEGUI_DOWNLOAD
+      tar -xzf $CEGUI_DOWNLOAD
       if [[ $OSTYPE == *darwin* ]] ; then
         echo "  Patching..."
-        cd $DEPS_SOURCE/$CEGUI
+        cd $DEPS_SOURCE/$CEGUI_VER
         sed -i "" -e "s/\"macPlugins.h\"/\"implementations\/mac\/macPlugins.h\"/g" cegui/src/CEGUIDynamicModule.cpp
         sed -i "" -e '1i\#include<CoreFoundation\/CoreFoundation.h>' cegui/include/CEGUIDynamicModule.h
       fi
     fi
-    cd $DEPS_SOURCE/$CEGUI
+    cd $DEPS_SOURCE/$CEGUI_VER
     mkdir -p $BUILDDIR
     cd $BUILDDIR
     echo "  Configuring..."
@@ -411,9 +404,95 @@ elif [ "$1" = "install-deps" ] ; then
       sed -i "" -e "s/-lCEGUIBase/-lCEGUIBase -lCEGUIFalagardWRBase -lCEGUIFreeImageImageCodec -lCEGUITinyXMLParser/g" $PREFIX/lib/pkgconfig/CEGUI.pc
     fi
     echo "  Done."
+}
+
+function ember_fetch_media()
+{
+  if [ $1 = "dev" ] ; then
+    MEDIAURL="http://amber.worldforge.org/media/media-dev/"
+    MEDIAVERSION="devmedia"
+    MEDIA_PREFETCH="set +e"
+    MEDIA_POSTFETCH="set -e"
+  else
+    MEDIAURL="http://downloads.sourceforge.net/worldforge/ember-media-${1}.tar.bz2"
+    MEDIAVERSION="releasemedia"
+    MEDIA_PREFETCH=""
+    MEDIA_POSTFETCH=""
+  fi
+  # Fetch Ember Media
+    if command -v rsync &> /dev/null; then
+      echo "Fetching media..."
+      cd $SOURCE/clients/ember/$BUILDDIR
+      $MEDIA_PREFETCH
+      make $MEDIAVERSION &> $LOGDIR/clients/ember/media.log
+      if [ $? != 0 ] ; then
+        echo "Could not fetch media. This may be caused by the media server being down, by the network being down, or by a firewall which prevents rsync from running. You need to get the media manually from $MEDIAURL"
+      else
+        echo "Media fetched."
+      fi
+      $MEDIA_POSTFETCH
+    else
+      echo "Rsync not found, skipping fetching of media. You will need to download and install it yourself from $MEDIAURL"
+    fi
+}
+
+# Show main help page if no arguments given
+if [ $# -eq 0 ] ; then
+  show_help "main"
+
+# If help command given, show help page
+elif [ "$1" = "help" ] ; then
+  if [ $# -eq 2 ] ; then
+    show_help $2
+  else
+    show_help "main"
   fi
 
-  echo "Install Done."
+  mkdir -p $PREFIX $SOURCE $DEPS_SOURCE
+
+# Dependencies install
+elif [ "$1" = "install-deps" ] ; then
+  if [ x$MSYSTEM = x"MINGW32" ] ; then
+    $HAMMERDIR/support/mingw_install_deps.sh
+    exit 0
+  fi
+  if [ $# -ne 2 ] ; then
+    echo "Missing required parameter!"
+    show_help "install-deps"
+    exit 1
+  fi
+
+  echo "Installing 3rd party dependencies..."
+
+  # Create deps log directory
+  mkdir -p $LOGDIR/deps
+
+  # Cg Toolkit
+  if [ "$2" = "all" ] || [ "$2" = "cg" ] ; then
+    install_deps_Cg
+  fi
+
+  # Ogre3D
+  if [ "$2" = "all" ] || [ "$2" = "ogre" ] ; then
+    install_deps_Ogre
+  fi
+
+  # freealut
+  if [ "$2" = "all" ] && [[ $OSTYPE == *darwin* ]] || [ "$2" = "freealut" ] ; then
+    install_deps_freealut
+  fi
+
+  # tolua++
+  if [ "$2" = "all" ] && [[ $OSTYPE == *darwin* ]] || [ "$2" = "tolua++" ] ; then
+    install_deps_tolua++
+  fi
+
+  # CEGUI
+  if [ "$2" = "all" ] || [ "$2" = "cegui" ] ; then
+    install_deps_CEGUI
+  fi
+
+  echo "Install of 3rd party dependencies is complete."
 
 # Source checkout
 elif [ "$1" = "checkout" ] ; then
@@ -422,7 +501,7 @@ elif [ "$1" = "checkout" ] ; then
     show_help "checkout"
     exit 1
   fi
-  echo "Fetching sources..."
+  echo "Checking out sources..."
 
   if [ "$2" = "libs" ] || [ "$2" = "all" ] ; then
 
@@ -509,7 +588,7 @@ elif [ "$1" = "checkout" ] ; then
     fi
   fi
 
-  echo "Checkout Done."
+  echo "Checkout complete."
 
 # Build source
 elif [ "$1" = "build" ] ; then
@@ -576,20 +655,8 @@ elif [ "$1" = "build" ] ; then
     buildwf "clients/ember"
     echo "  Done."
 
-    if command -v rsync &> /dev/null; then
-      echo "Fetching media..."
-      cd $SOURCE/clients/ember/$BUILDDIR
-      set +e
-      make devmedia &> $LOGDIR/clients/ember/media.log
-      if [ $? != 0 ] ; then
-        echo "Could not fetch media. This can be caused by the amber.worldforge.org server being down, the network being down or a firewall which prevents rsync to be run. You need to get the media manually from http://amber.worldforge.org/media/"
-      else
-        echo "Media fetched."
-      fi
-      set -e
-    else
-      echo "Rsync not found, skipping fetching media. You will need to download and install it yourself from http://amber.worldforge.org/media/."
-    fi
+    # Ember media
+    ember_fetch_media "dev"
 
   fi
 
@@ -614,31 +681,18 @@ elif [ "$1" = "build" ] ; then
     echo "  Done."
   fi
 
-
   if [ "$2" = "webember" ] || [ "$2" = "all" ] ; then
 
     echo "  WebEmber..."
     CONFIGURE_EXTRA_FLAGS="$CONFIGURE_EXTRA_FLAGS --enable-webember"
     #we need to change the BUILDDIR to separate the ember and webember build directories.
     #the strange thing is that if BUILDDIR is 6+ character on win32, the build will fail with missing headers.
-    export BUILDDIR=web$BUILDDIR
+    export BUILDDIR=web${BUILDDIR}
     buildwf "clients/ember" "webember"
     echo "  Done."
 
-    if command -v rsync &> /dev/null; then
-      echo "Fetching media..."
-      cd $SOURCE/clients/ember/$BUILDDIR
-      set +e
-      make devmedia &> $LOGDIR/webember/media.log
-      if [ $? != 0 ] ; then
-        echo "Could not fetch media. This can be caused by the amber.worldforge.org server being down, the network being down or a firewall which prevents rsync to be run. You need to get the media manually from http://amber.worldforge.org/media/"
-      else
-        echo "Media fetched."
-      fi
-      set -e
-    else
-      echo "Rsync not found, skipping fetching media. You will need to download and install it yourself."
-    fi
+    # WebEmber media
+    ember_fetch_media "dev"
 
     # WebEmber
     echo "  WebEmber plugin..."
@@ -674,7 +728,7 @@ elif [ "$1" = "build" ] ; then
     echo "  Done."
   fi
 
-  echo "Build Done."
+  echo "Build complete."
 
 elif [ "$1" = "clean" ] ; then
   if [ $# -ne 2 ] ; then
@@ -685,16 +739,144 @@ elif [ "$1" = "clean" ] ; then
 
   # Delete build directory
   if [ "$2" = "cegui" ] ; then
-    rm -rf $DEPS_SOURCE/$CEGUI/$BUILDDIR
+    rm -rf $DEPS_SOURCE/$CEGUI_VER/$BUILDDIR
   elif [ "$2" = "ogre" ] ; then
-    rm -rf $DEPS_SOURCE/$OGRE/ogre/$BUILDDIR
+    rm -rf $DEPS_SOURCE/$OGRE_VER/ogre/$BUILDDIR
   else
     rm -rf $SOURCE/$2/$BUILDDIR
   fi
 
 elif [ "$1" = "release_ember" ] ; then
-  cd $SOURCE/clients/ember
-  git checkout "release-$2"
+  # Set configuration for building a release
+  if [[ $OSTYPE != *darwin* ]] ; then
+    export CXXFLAGS="$CXXFLAGS -O3 -g0 -s"
+    export CFLAGS="$CFLAGS -O3 -g0 -s"
+  fi
+  export APP_DIR_ROOT="$WORKDIR/Ember.AppDir"
+
+  # Install external dependencies
+  echo "Installing 3rd party dependencies..."
+  # Create deps log directory
+  mkdir -p $LOGDIR/deps
+  install_deps_Cg
+  install_deps_Ogre
+  if [[ $OSTYPE == *darwin* ]] ; then
+    install_deps_freealut
+    install_deps_tolua++
+  fi
+  install_deps_CEGUI
+  echo "Install of 3rd party dependencies is complete."
+
+  # Source checkout
+  echo "Checking out sources..."
+    mkdir -p $SOURCE/libs
+    cd $SOURCE/libs
+    echo "  Varconf..."
+    checkoutwf "varconf"
+    cd $SOURCE/libs/varconf
+    git checkout $VARCONF_VER
+    echo "  Done."
+    cd $SOURCE/libs
+    echo "  Atlas-C++..."
+    checkoutwf "atlas-cpp"
+    cd $SOURCE/libs/atlas-cpp
+    git checkout $ATLASCPP_VER
+    echo "  Done."
+# Needs to be removed for Ember version 0.8.0 and above
+    cd $SOURCE/libs
+    echo "  Skstream..."
+    checkoutwf "skstream"
+    cd $SOURCE/libs/skstream
+    git checkout $SKSTREAM_VER
+    echo "  Done."
+    cd $SOURCE/libs
+    echo "  Wfmath..."
+    checkoutwf "wfmath"
+    cd $SOURCE/libs/wfmath
+    git checkout $WFMATH_VER
+    echo "  Done."
+    cd $SOURCE/libs
+    echo "  Eris..."
+    checkoutwf "eris"
+    cd $SOURCE/libs/eris
+    git checkout $ERIS_VER
+    echo "  Done."
+    cd $SOURCE/libs
+    echo "  Libwfut..."
+    checkoutwf "libwfut"
+    cd $SOURCE/libs/libwfut
+    git checkout $WFUT_VER
+    echo "  Done."
+    cd $SOURCE/libs
+    echo "  Mercator..."
+    checkoutwf "mercator"
+    cd $SOURCE/libs/mercator
+    git checkout $MERCATOR_VER
+    echo "  Done."
+    echo "  Ember client..."
+    mkdir -p $SOURCE/clients
+    cd $SOURCE/clients
+    checkoutwf "ember"
+    cd $SOURCE/clients/ember
+    git checkout "release-$2"
+    echo "  Done."
+  echo "Checkout complete."
+
+  # Build source
+  echo "Building sources..."
+    # Build libraries
+    echo "  Varconf..."
+    buildwf "libs/varconf"
+    echo "  Done."
+# Needs to be removed for Ember version 0.8.0 and above
+    echo "  Skstream..."
+    buildwf "libs/skstream"
+    echo "  Done."
+    echo "  Wfmath..."
+    buildwf "libs/wfmath"
+    echo "  Done."
+    echo "  Atlas-C++..."
+    buildwf "libs/atlas-cpp"
+    echo "  Done."
+    echo "  Mercator..."
+    buildwf "libs/mercator"
+    echo "  Done."
+    echo "  Eris..."
+    buildwf "libs/eris"
+    echo "  Done."
+    echo "  Libwfut..."
+    buildwf "libs/libwfut"
+    echo "  Done."
+    # Build Ember client
+    echo "  Ember client..."
+    buildwf "clients/ember"
+    echo "  Done."
+    # Fetch Ember media
+    ember_fetch_media $2
+  echo "Build complete."
+
+  # Check for Ember release target option
+  if [ x"$3" = x"" ] || [ "$3" = "image" ] ; then
+    # making an AppImage/AppBundle
+    if [[ $OSTYPE == *darwin* ]] ; then
+      echo "Creating AppBundle."
+      . $HAMMERDIR/support/AppBundler.sh
+      echo "AppBundle creation complete."
+    else
+      echo "Creating AppImage."
+      mkdir -p $LOGDIR/AppImage/
+      . $HAMMERDIR/support/linux_AppDir_create.sh 2>&1 | tee $LOGDIR/AppImage/AppDir.log
+      echo "AppImage will be created from the AppDir at $APP_DIR_ROOT and placed into $WORKDIR."
+      python $HAMMERDIR/../AppImageKit/AppImageAssistant.AppDir/package $APP_DIR_ROOT $WORKDIR/ember-${2}-x86_$BUILDDIR create new 2>&1 | tee $LOGDIR/AppImage/AppImage.log
+      echo "AppImage creation complete."
+    fi
+  else 
+    # making a standard directory
+    echo "Creating release directory."
+    cd $HAMMERDIR
+    . $HAMMERDIR/support/linux_release_bundle.sh
+    echo "Release directory created."
+  fi
 
 else
   echo "Invalid command!"

--- a/support/AppBundler.sh
+++ b/support/AppBundler.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-#This script will create a portable App for Mac OS X.
+# This script will create a portable App for Mac OS X.
+# It should be run through hammer.sh or from the hammer directory. 
 
 
 set -e

--- a/support/linux_AppDir_create.sh
+++ b/support/linux_AppDir_create.sh
@@ -1,16 +1,125 @@
 #!/bin/bash
 
-# Script to copy appropriate libraries into the release directory 
-# to allow creation of an ember AppDir and AppImage.
-# Copyright: 2013 Olek Wojnar
+# Script to create, and copy appropriate libraries into, the AppDir 
+# directory; thus to allow creation of an ember AppImage.
+# This script assumes that the AppImageKit source directory is installed 
+# in the same parent directory that the hammer directory is installed in.
+# Incorporates portions of linux_release_bundle.sh by the WorldForge project.
+# This script is designed to be run from hammer.sh, 
+# running it directly is NOT recommended.
+# Copyright: 2013-2014 Olek Wojnar
 # License: GPL-2+
 
-. $PWD/support/linux_release_bundle.sh
+APP_DIR="$APP_DIR_ROOT/usr"
+EMBER_BIN="$APP_DIR/bin/ember.bin"
 
-EMBER_BIN="$REL/bin/ember.bin"
-APP_DIR="$PWD/Ember.AppDir"
+# Create and populate the AppDir
 
-cd $REL/lib
+mkdir -p $APP_DIR
+cd $APP_DIR_ROOT
+curl -OL https://raw.github.com/worldforge/ember/master/ember.desktop
+curl -OL https://raw.github.com/worldforge/ember/master/media/ember.png
+cp -a "ember.png" ".DirIcon"
+cp $HAMMERDIR/../AppImageKit/AppRun .
+
+
+####Adapted from linux_release_bundle.sh####
+#This script will copy everything from work/local to the AppDir.
+#It will recursively detect all ember dependencies, 
+#which are installed into the $PREFIX directory.
+#Also, it will automatically resolve symlinks and copy the file only, 
+#because symlinks are not rpath compatible.
+
+export LD_LIBRARY_PATH=$PREFIX/lib
+if [ ! -d $PREFIX/lib ] ; then
+  echo "Error: $PREFIX/lib directory does not exist!"
+  exit 1
+fi
+
+mkdir -p $APP_DIR/bin
+cp $PREFIX/bin/ember $APP_DIR/bin/ember
+cp $PREFIX/bin/ember.bin $APP_DIR/bin/ember.bin
+
+mkdir -p $APP_DIR/etc/ember
+cp -r $PREFIX/etc/ember/* $APP_DIR/etc/ember
+
+mkdir -p $APP_DIR/share/ember
+cp -r $PREFIX/share/ember/* $APP_DIR/share/ember
+
+#copy Ogre plugins and cg, which are not found automatically by the linker.
+mkdir -p $APP_DIR/lib/OGRE
+cp $PREFIX/lib/OGRE/Plugin_CgProgramManager.so $APP_DIR/lib/OGRE
+cp $PREFIX/lib/OGRE/Plugin_OctreeSceneManager.so $APP_DIR/lib/OGRE
+cp $PREFIX/lib/OGRE/Plugin_ParticleFX.so $APP_DIR/lib/OGRE
+cp $PREFIX/lib/OGRE/RenderSystem_GL.so $APP_DIR/lib/OGRE
+cp $PREFIX/lib/libCg.so $APP_DIR/lib
+
+#remove temporary work file.
+if [ -f tmp_ldd.txt ] ; then
+  rm tmp_ldd.txt
+fi
+touch tmp_ldd.txt
+
+function is_processed()
+{
+  cat tmp_ldd.txt | while read line2 ; do
+    if [ "$line2" == "$1" ] ; then
+      echo yes
+      break;
+    fi
+  done
+}
+
+#lists all dependencies recursively which are installed in $PREFIX 
+function list_deps()
+{
+  echo "`ldd \"$1\"`" | while read line ; do
+    if [[ $line == *"${PREFIX}"* ]] ; then
+      
+      #cut text until > character
+      line="`echo $line | cut -s -d '>' -f 2`"
+      #cut text after ( character
+      line="`echo $line | cut -s -d '(' -f 1`"
+      #trim
+      line="`echo $line`"
+
+      if [ "$line" != "" ] && [ -f $line ] ; then
+        #check in the tested list if it was already processed(endless loop protection)
+        ret="`is_processed $line`"
+        if [ "$ret" != "yes" ] ; then
+          echo $line >> tmp_ldd.txt
+          echo $line
+          list_deps $line
+        fi
+      fi
+    fi
+  done
+}
+
+function copy_sharedlib()
+{
+  echo "copying $1"
+  if [ -s "$1" ] ; then
+    loc="`readlink -f $1`"
+  else
+    loc="$1"
+  fi
+  out="$APP_DIR/lib/`basename \"$1\"`"
+  cp "$loc" "$out" 
+  chmod 0755 "$out"
+  chrpath -r "../lib:lib" "$out" || true
+}
+echo "Recursively obtaining ember dependencies."
+list_deps "$APP_DIR/bin/ember.bin" | while read line; do copy_sharedlib "$line"; done
+
+#remove temporary work file.
+if [ -f tmp_ldd.txt ] ; then
+  rm tmp_ldd.txt
+fi
+####End adapted from linux_release_bundle.sh####
+
+
+cd $APP_DIR/lib
 
 for LIBNAME in `ldd $EMBER_BIN | grep -o "/.*\s" ` 
 do 
@@ -37,27 +146,17 @@ fi
 
 # Manually add and remove libraries which don't behave appropriately.
 
-rm $REL/lib/ld-linux*
-rm $REL/lib/libc.so*
-rm $REL/lib/libdl.so*
-rm $REL/lib/libGL.so*
-rm $REL/lib/libglapi.so*
-rm $REL/lib/libm.so*
-rm $REL/lib/libpthread.so*
-rm $REL/lib/libresolv.so*
-rm $REL/lib/librt.so*
-rm $REL/lib/librtmp.so*
-rm $REL/lib/libX11.so*
+rm $APP_DIR/lib/ld-linux*
+rm $APP_DIR/lib/libc.so*
+rm $APP_DIR/lib/libdl.so*
+rm $APP_DIR/lib/libGL.so*
+rm $APP_DIR/lib/libglapi.so*
+rm $APP_DIR/lib/libm.so*
+rm $APP_DIR/lib/libpthread.so*
+rm $APP_DIR/lib/libresolv.so*
+rm $APP_DIR/lib/librt.so*
+rm $APP_DIR/lib/librtmp.so*
+rm $APP_DIR/lib/libX11.so*
 
-cp $WORK/lib/libCEGUIFalagardWRBase* $REL/lib
-cp $WORK/lib/libCEGUIFreeImageImageCodec* $REL/lib
-cp $WORK/lib/libCEGUITinyXMLParser* $REL/lib
-
-# Create and populate the AppDir
-
-mkdir -p $APP_DIR/usr
-cd $APP_DIR
-cp -r $REL/* usr
-curl -OL https://raw.github.com/worldforge/ember/master/ember.desktop
-curl -OL https://raw.github.com/worldforge/ember/master/media/ember.png
-cp -a "ember.png" ".DirIcon"
+cp -d $PREFIX/lib/libCEGUI* $APP_DIR/lib
+cp -r $PREFIX/lib/cegui* $APP_DIR/lib

--- a/support/linux_release_bundle.sh
+++ b/support/linux_release_bundle.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 
-#this script will copy everything from work/local to release
-#it will recursively detect all ember dependencies, which are installed into the $WORK dir.
-#also it will automatically resolve symlinks and copies the file only, because symlinks are not rpath compatible.
-#it will also copy install.sh uninstall.sh and npWebEmber.so files for webember if availible
+# This script will copy everything from work/local to work/release; it will also
+# recursively detect all ember dependencies which are installed in the $WORK dir.
+# It will also automatically resolve symlinks and copies the file only, because symlinks are not rpath compatible.
+# It will also copy install.sh, uninstall.sh, and npWebEmber.so files for webember, if they are availible.
 
 WORK="$PWD/work/local"
-REL="$PWD/release"
+REL="$PWD/work/release"
 
 export LD_LIBRARY_PATH="$WORK/lib"
-if [ ! -d $WORK ] ; then
-  echo "Error: $WORK directory does not exist!"
+if [ ! -d $WORK/lib ] ; then
+  echo "Error: $WORK/lib directory does not exist!"
   exit 1
 fi
 
@@ -26,7 +26,10 @@ cp -r $WORK/share/ember/* $REL/share/ember
 
 #copy Ogre plugins and cg, which are not found automatically by the linker.
 mkdir -p $REL/lib/OGRE
-cp $WORK/lib/OGRE/*.so $REL/lib/OGRE
+cp $WORK/lib/OGRE/Plugin_CgProgramManager.so $REL/lib/OGRE
+cp $WORK/lib/OGRE/Plugin_OctreeSceneManager.so $REL/lib/OGRE
+cp $WORK/lib/OGRE/Plugin_ParticleFX.so $REL/lib/OGRE
+cp $WORK/lib/OGRE/RenderSystem_GL.so $REL/lib/OGRE
 cp $WORK/lib/libCg.so $REL/lib
 
 #remove temporary work file.
@@ -82,7 +85,7 @@ function copy_sharedlib()
   out="$REL/lib/`basename \"$1\"`"
   cp "$loc" "$out" 
   chmod 0755 "$out"
-  chrpath -r "../lib:lib" "$out"
+  chrpath -r "../lib:lib" "$out" || true
 }
 echo "gettings ember dependencies recursively"
 list_deps "$REL/bin/ember.bin" | while read line; do copy_sharedlib "$line"; done

--- a/support/mingw_install_deps.sh
+++ b/support/mingw_install_deps.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-export PREFIX="$PWD/work/local"
+export PREFIX="$HAMMERDIR/work/local"
 export PATH="$PREFIX/bin:$PATH"
 export CPATH="$PREFIX/include:$CPATH"
 export LIBRARY_PATH="$PREFIX/lib:$LIBRARY_PATH"
@@ -33,12 +33,12 @@ if [ "$LDFLAGS" != "" ] ; then
 	unset LDFLAGS
 fi
 
-LOGDIR=$PWD/work/logs/deps
-BUILDDEPS=$PWD/work/build/deps
+LOGDIR=$HAMMERDIR/work/logs/deps
+BUILDDEPS=$HAMMERDIR/work/build/deps
 PACKAGEDIR=$BUILDDEPS/packages
 DLDIR=$BUILDDEPS/downloads
 LOCKDIR=$BUILDDEPS/locks
-SUPPORTDIR=$PWD/support
+SUPPORTDIR=$HAMMERDIR/support
 
 mkdir -p $LOGDIR
 mkdir -p $BUILDDEPS


### PR DESCRIPTION
- Support for building AppImages/AppBundles with "release_ember" command
- Relocate all support scripts to "support" directory
- Cleanups to enhance ease of understanding and maintainability
- All build artifacts actually end up in the "work" directory now
- All existing functionality maintained fairly transparently
- Move all variables likely to be modifed (e.g. library version numbers)
  to start of hammer.sh script
- Rebased on top of Sean's metaserver commit
