### PR TITLE
Automatically build key portions of AppImageKit

### DIFF
--- a/README
+++ b/README
@@ -4,7 +4,3 @@ Tool for installing deps, checking out source, and compiling the application.
 Execute hammer.sh for help.
 
 All build artifacts are placed in the "work" directory.
-
-Note: If you are building an AppImage, these scripts assumes that the 
-AppImageKit source directory is installed in the same parent directory 
-that the hammer directory is installed in.

--- a/support/linux_AppDir_create.sh
+++ b/support/linux_AppDir_create.sh
@@ -20,7 +20,7 @@ cd $APP_DIR_ROOT
 curl -OL https://raw.github.com/worldforge/ember/master/ember.desktop
 curl -OL https://raw.github.com/worldforge/ember/master/media/ember.png
 cp -a "ember.png" ".DirIcon"
-cp $HAMMERDIR/../AppImageKit/AppRun .
+cp $DEPS_BUILD/AppImageKit/AppRun .
 
 
 ####Adapted from linux_release_bundle.sh####

--- a/support/linux_AppDir_create.sh
+++ b/support/linux_AppDir_create.sh
@@ -146,6 +146,9 @@ fi
 
 # Manually add and remove libraries which don't behave appropriately.
 
+# Some libraries may not be present. If they are not present, continue processing.
+set +e
+
 rm $APP_DIR/lib/ld-linux*
 rm $APP_DIR/lib/libc.so*
 rm $APP_DIR/lib/libdl.so*
@@ -157,6 +160,9 @@ rm $APP_DIR/lib/libresolv.so*
 rm $APP_DIR/lib/librt.so*
 rm $APP_DIR/lib/librtmp.so*
 rm $APP_DIR/lib/libX11.so*
+
+# Resume exit-on-fail behavior.
+set -e
 
 cp -d $PREFIX/lib/libCEGUI* $APP_DIR/lib
 cp -r $PREFIX/lib/cegui* $APP_DIR/lib


### PR DESCRIPTION
- Build only the portion necessary for creating Ember AppImages
- Use the resulting AppImageKit components to create the Ember AppImage
- This will remove the requirement to install/compile AppImageKit manually
- Minor cleanup/adjustment of existing AppImage code
